### PR TITLE
fix: add recipe build arg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,7 @@ jobs:
           build-args: |
             FEDORA_MAJOR_VERSION=${{ env.FEDORA_MAJOR_VERSION }}
             BASE_CONTAINER_URL=${{ env.BASE_CONTAINER_URL }}
+            RECIPE=${{ matrix.recipe }}
           labels: ${{ steps.meta.outputs.labels }}
           oci: false
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,6 @@
 ARG FEDORA_MAJOR_VERSION=37
 ARG BASE_CONTAINER_URL=ghcr.io/ublue-os/silverblue-main
+ARG RECIPE
 
 FROM ${BASE_CONTAINER_URL}:${FEDORA_MAJOR_VERSION}
 
@@ -7,7 +8,7 @@ FROM ${BASE_CONTAINER_URL}:${FEDORA_MAJOR_VERSION}
 COPY etc /etc
 # COPY usr /usr
 
-COPY recipe.yml /tmp/ublue-recipe.yml
+COPY ${RECIPE} /tmp/ublue-recipe.yml
 
 # yq used in build.sh and the setup-flatpaks recipe to read the recipe.yml
 # copied from the official container image as it's not avaible as an rpm


### PR DESCRIPTION
startingpoint has been updated to use multiple recipes. currently this process is broken as the default recipe is always used. this fixes this by adding a build arg to the containerfile and github workflow build.