### PR TITLE
fix: use RECIPE arg

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,8 @@
 ARG FEDORA_MAJOR_VERSION=37
 ARG BASE_CONTAINER_URL=ghcr.io/ublue-os/silverblue-main
-ARG RECIPE
 
 FROM ${BASE_CONTAINER_URL}:${FEDORA_MAJOR_VERSION}
+ARG RECIPE
 
 # copy over configuration files
 COPY etc /etc


### PR DESCRIPTION
The RECIPE arg in the Containerfile is empty when it is before the FROM statement. This moves the arg so that it can be used.